### PR TITLE
added rule to eslint for function return types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,16 @@
         "semi": ["error", "always"],
         "quotes": ["warn", "single"],
         "no-unused-vars": "warn",
-        "@typescript-eslint/no-unused-vars": "warn"
+        "@typescript-eslint/no-unused-vars": "warn",
+        "@typescript-eslint/explicit-function-return-type": [
+            "error",
+            {
+                "allowExpressions": true,
+                "allowTypedFunctionExpressions": true,
+                "allowHigherOrderFunctions": true,
+                "allowDirectConstAssertionInArrowFunctions": true,
+                "allowConciseArrowFunctionExpressionsStartingWithVoid": true
+            }
+        ]
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,10 @@ import { getASTCodemodCode } from './utils/ast-transformations/run-ast-transform
 import { getReactCompDom } from './utils/enzyme-helper/get-dom-enzyme';
 import { genPrompt } from './utils/prompt-generation/generate-prompt';
 import { extractCodeContentToFile } from './utils/code-extractor/extract-code';
-import { runTestAndAnalyzeFile } from './utils/enzyme-helper/run-test-analysis';
+import {
+    runTestAndAnalyzeFile,
+    RTLTestResult,
+} from './utils/enzyme-helper/run-test-analysis';
 import { setJestBinaryPath, setOutputResultsPath } from './utils/config';
 
 /**
@@ -19,10 +22,11 @@ import { setJestBinaryPath, setOutputResultsPath } from './utils/config';
 export { setJestBinaryPath, setOutputResultsPath };
 
 // Convert with AST
-export const converWithAST = (filePath: string) => getASTCodemodCode(filePath);
+export const converWithAST = (filePath: string): string =>
+    getASTCodemodCode(filePath);
 
 // Get rendered component DOM
-export const getReactComponentDOM = (filePath: string) =>
+export const getReactComponentDOM = async (filePath: string): Promise<string> =>
     getReactCompDom(filePath);
 
 // Generate prompt
@@ -31,7 +35,7 @@ export const generatePrompt = (
     getByTestIdAttribute = 'data-testid',
     astCodemodOutput: string,
     renderedCompCode: string,
-) =>
+): string =>
     genPrompt(
         filePath,
         getByTestIdAttribute,
@@ -40,9 +44,9 @@ export const generatePrompt = (
     );
 
 // Extract code
-export const extractCodeContent = (LLMresponse: string) =>
+export const extractCodeContent = (LLMresponse: string): string =>
     extractCodeContentToFile(LLMresponse);
 
 // Run generated file and announce result
-export const runTestAndAnalyze = (filePath: string) =>
+export const runTestAndAnalyze = (filePath: string): Promise<RTLTestResult> =>
     runTestAndAnalyzeFile(filePath);

--- a/src/utils/ast-transformations/individual-transformations/convert-find.ts
+++ b/src/utils/ast-transformations/individual-transformations/convert-find.ts
@@ -14,7 +14,7 @@ import { astLogger } from '../utils/ast-logger';
  * @param j
  * @param root
  */
-export const convertFind = (j: JSCodeshift, root: Collection) => {
+export const convertFind = (j: JSCodeshift, root: Collection): void => {
     astLogger.verbose('Querying for .find');
     // Find all call expressions with the callee property name 'find'
     const findCalls = root.find(j.CallExpression, {

--- a/src/utils/ast-transformations/individual-transformations/convert-mount-shallow-methods.ts
+++ b/src/utils/ast-transformations/individual-transformations/convert-mount-shallow-methods.ts
@@ -127,7 +127,7 @@ export const convertMountShallowMethods = (
      * Sometimes the function that calls mount or shallow method is called render
      * To avoid any conflicts with RTL we need to rename it to something else than render
      */
-    function changeRenderFuncName() {
+    function changeRenderFuncName(): void {
         // Find all calls to that function and change to the new value
         const renderFuncReferenceDeclarations = root.find(j.CallExpression, {
             callee: {

--- a/src/utils/ast-transformations/individual-transformations/convert-mount-shallow-vars.ts
+++ b/src/utils/ast-transformations/individual-transformations/convert-mount-shallow-vars.ts
@@ -179,7 +179,7 @@ export const convertMountShallowVars = (
      * Construct and replace with new expression
      * @param path
      */
-    function replaceWithExpression(path: ASTPath) {
+    function replaceWithExpression(path: ASTPath): void {
         // Get the declaration and add to the variable refs
         const varDeclarationNode = path.get('declarations', 0, 'id').node;
         varsRenderRefs.push(varDeclarationNode.name);

--- a/src/utils/ast-transformations/individual-transformations/convert-simulate.ts
+++ b/src/utils/ast-transformations/individual-transformations/convert-simulate.ts
@@ -20,7 +20,7 @@ import { addComment } from '../utils/add-comment';
  * @param root - The root AST node
  * @returns - Returns imported userEvent Library
  */
-export const convertSimulate = (j: JSCodeshift, root: Collection) => {
+export const convertSimulate = (j: JSCodeshift, root: Collection): void => {
     // Find all call expressions with the callee property name '.simulate'
     astLogger.verbose('Query for simulate');
     const simulateCalls = root.find(j.CallExpression, {

--- a/src/utils/ast-transformations/individual-transformations/remove-enzyme-hostNodes-method.ts
+++ b/src/utils/ast-transformations/individual-transformations/remove-enzyme-hostNodes-method.ts
@@ -12,7 +12,7 @@ import { astLogger } from '../utils/ast-logger';
  * @param root - root AST node
  * @returns {void} - The function does not return a value but mutates the AST directly.
  */
-export const convertHostNodes = (j: JSCodeshift, root: Collection) => {
+export const convertHostNodes = (j: JSCodeshift, root: Collection): void => {
     // Find the hostNodes call expression within the provided AST root
     astLogger.verbose('Query for hostNodes');
     root.find(j.CallExpression, {

--- a/src/utils/ast-transformations/utils/add-comment.ts
+++ b/src/utils/ast-transformations/utils/add-comment.ts
@@ -6,7 +6,7 @@ import type { ASTPath } from 'jscodeshift';
  * @param comment
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const addComment = (currentPath: ASTPath<any>, comment: string) => {
+export const addComment = (currentPath: ASTPath, comment: string): void => {
     // Get needed parent node
     // TODO: check on more Enzyme files
     const commonTopLevelNodeTypes = [
@@ -27,12 +27,9 @@ export const addComment = (currentPath: ASTPath<any>, comment: string) => {
  * @returns
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const findParentNode = (currentPath: ASTPath<any>, types: string[]) => {
+const findParentNode = (currentPath: ASTPath, types: string[]): ASTPath => {
     let currentNode = currentPath;
 
-    // while (currentNode && currentNode.getValueProperty('type') !== type) {
-    // 	currentNode = currentNode.parent;
-    // }
     while (currentNode) {
         const parent = currentNode.parent;
         if (!parent) {


### PR DESCRIPTION
## Summary
Added eslint rule to error if no function return type was provided

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] Merged latest main
- [x] New and existing unit tests pass locally with my changes
