### PR TITLE
lowered sleep command for test

### DIFF
--- a/src/support/shell-helper/shell-helper.jest.ts
+++ b/src/support/shell-helper/shell-helper.jest.ts
@@ -23,7 +23,7 @@ describe('runCommand Integration Test', () => {
     });
 
     it('should kill the process if it runs longer than the allowed time', async () => {
-        const command = 'sleep 10'
+        const command = 'sleep 10';
         const timeout = 2000; // Set a timeout of 2 seconds
 
         try {


### PR DESCRIPTION
## Summary
1. Make the test sleep for 10 instead of 302

## Checklist:
- [x] Merged latest main
- [x] New and existing unit tests pass locally with my changes
