### PR TITLE
Made testid param optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ const callLLMFunctionExample: LLMCallFunction = async (
 const convertFiles = async (filePaths: string[]) => {
     const results = await convertTestFiles({
         filePaths: filePaths,
-        jestBinaryPath: 'npx jest',
+        jestBinaryPath: 'npx jest', // this command should be able to run one jest test file, e.g. `npx jest <filePath>`
         outputResultsPath: 'ai-conversion-testing/temp',
-        testId: 'data-test',
+        testId: '<your_custom_test_id_attribute', // defaults to RTL `data-testid` attribute
         llmCallFunction: callLLMFunctionExample,
         enableFeedbackStep: true,
     });
@@ -110,9 +110,9 @@ const convertTestFile = async (filePath: string): Promise<void> => {
     // Initialize config
     const config = initializeConfig({
         filePath,
-        jestBinaryPath: 'npx jest',
+        jestBinaryPath: 'npx jest', // this command should be able to run one jest test file, e.g. `npx jest <filePath>`
         outputResultsPath: 'ai-conversion-testing/temp',
-        testId: 'data-test',
+        testId: '<your_custom_test_id_attribute', // defaults to RTL `data-testid` attribute
     });
 
     // Perform AST conversion

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/enzyme-to-rtl-codemod",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "AST codemod for Enzyme to RTL with AI integration capabilities",
   "keywords": ["slack", "enzyme", "rtl", "codemod"],
   "author": "Salesforce, Inc.",

--- a/src/support/config/config.ts
+++ b/src/support/config/config.ts
@@ -89,7 +89,7 @@ interface InitializeConfigArgs {
     filePath: string;
     jestBinaryPath: string;
     outputResultsPath: string;
-    testId: string;
+    testId?: string;
     logLevel?: LogLevel;
 }
 
@@ -122,7 +122,7 @@ export const initializeConfig = ({
     filePath,
     jestBinaryPath,
     outputResultsPath,
-    testId,
+    testId = 'data-testid',
     logLevel = 'info',
 }: InitializeConfigArgs): Config => {
     // Check if the shared config has already been initialized

--- a/src/support/workflows/convert-test-files.ts
+++ b/src/support/workflows/convert-test-files.ts
@@ -37,7 +37,7 @@ export interface TestResults {
  * @param {string} [params.logLevel] - Optional log level to control verbosity of logs. 'info' or 'verbose'
  * @param {string} params.jestBinaryPath - Path to the Jest binary for running tests.
  * @param {string} params.outputResultsPath - The directory where output results should be stored.
- * @param {string} params.testId - The identifier for tracking and processing tests.
+ * @param {string} params.testId - Optional identifier getByTestId(testId) queries.
  * @param {LLMCallFunction} params.llmCallFunction - Function for making LLM API calls to process the tests.
  * @param {string[]} [params.extendInitialPrompt] - Optional array of additional instructions for the initial LLM prompt.
  * @param {boolean} params.enableFeedbackStep - Flag indicating whether to enable feedback-based refinement in case of failed tests.
@@ -49,7 +49,7 @@ export const convertTestFiles = async ({
     logLevel,
     jestBinaryPath,
     outputResultsPath,
-    testId,
+    testId = 'data-testid',
     llmCallFunction,
     extendInitialPrompt,
     enableFeedbackStep,
@@ -59,7 +59,7 @@ export const convertTestFiles = async ({
     logLevel?: string;
     jestBinaryPath: string;
     outputResultsPath: string;
-    testId: string;
+    testId?: string;
     llmCallFunction: LLMCallFunction;
     extendInitialPrompt?: string[];
     enableFeedbackStep: boolean;


### PR DESCRIPTION
## Summary
1. Made testid optional, as some projects might use the RTL default testid attribute
2. Not a breaking change. Existing setup should be compatible

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing
- [ ] Tested on an external project

## Checklist:
- [x] Merged latest main
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
- [x] Bumped npm version
